### PR TITLE
Update thulac.h

### DIFF
--- a/include/thulac.h
+++ b/include/thulac.h
@@ -343,7 +343,7 @@ int foo(int a, int b) {
     //    a = b;
     return a+b;
 }
-THULAC_result& multiTreadCut(const std::string &in, THULAC& lac, int thread) {
+THULAC_result multiThreadCut(const std::string &in, THULAC& lac, int thread) {
     std::vector<std::future<THULAC_result>> t;
     THULAC_result output;
     std::vector<std::string> splited = eqSeg(in, thread);


### PR DESCRIPTION
fix warning :


```
include/thulac.h:348:19: 警告：返回了对局部变量的‘output’的引用 [-Wreturn-local-addr]
     THULAC_result output;
                   ^
```